### PR TITLE
Implement #13

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -77,7 +77,7 @@ class Simulator {
         const result = this.navigator.computeStep(this._dt);
         // Determine status: avoiding if clearance is low
         if (result) {
-          const clearance = _agvClearance(this.agv.x, this.agv.y, this.obstacles);
+          const clearance = _agvClearance(this.agv.x, this.agv.y, this.agv.theta, this.obstacles);
           this._navStatus = clearance < 1.5 ? 'avoiding' : 'running';
         }
       }


### PR DESCRIPTION
Closes #13

## Fix

In `simulator.js` `_loop()`, `_agvClearance` was called with only 3 arguments — `theta` was omitted, causing `this.obstacles` to land in the `theta` slot and `obstacles` (4th param) to be `undefined`. When the function accessed `obstacles.length`, it threw:

```
TypeError: Cannot read properties of undefined (reading 'length')
```

**Change:** Added `this.agv.theta` as the 3rd argument:
```js
// Before (broken)
const clearance = _agvClearance(this.agv.x, this.agv.y, this.obstacles);

// After (fixed)
const clearance = _agvClearance(this.agv.x, this.agv.y, this.agv.theta, this.obstacles);
```

## Acceptance Criteria

- [x] Pressing Start after placing obstacles no longer throws TypeError
- [x] `_agvClearance` in `_loop()` called with all 4 correct args: `(ax, ay, theta, obstacles)`
- [x] Status badge correctly shows `avoiding` when clearance is low
- [x] No JavaScript errors during navigation run